### PR TITLE
fix coverage reports

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "usr"
+  - "**/*.test.cc"
+  - "external"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with: { submodules: recursive }
+        with: { submodules: recursive, fetch-depth: 0 }
       - uses: conda-incubator/setup-miniconda@v2
         with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true }
       - name: install dependencies
@@ -23,10 +23,16 @@ jobs:
           export CXXFLAGS="$CXXFLAGS --coverage -O0 -UNDEBUG"
           ./configure --prefix="$PREFIX" --without-benchmark
           make check
+      - name: create & post coverage report
+        shell: bash -l {0}
+        run: |
+          pushd test
+          gcov -pbs ../../gmpxxll mpz_class.test.gcda
+          popd
+          curl -s https://codecov.io/bash | bash -s - -X gcov -R `pwd` .
       - name: show logs
         run: grep "" /dev/null `find -name '*.log'` || true
         if: ${{ always() }}
-      - uses: codecov/codecov-action@v1
 
 env:
   MAKEFLAGS: -j2


### PR DESCRIPTION
the codecov action is not flexible enough so we create the gcov reports manually and then post them to codecov with the official uploader again.